### PR TITLE
Added code to import Libraries.io Java GitHub repository list

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ repository analysis code are refactored, we can safely discard all MySQL related
 
 ### Start MongoDB Server on World of Code da1
 
-Make sure MongoDB server is not already running. Run the following command at `/da1_data/play/heh/mongodb/bin`.
+Make sure MongoDB server is not already running. Run the following command.
 
 ```shell script
-nohup ./mongod --auth --dbpath /da1_data/play/heh/mongodb/data \
+nohup /da1_data/play/heh/mongodb/bin/mongod --auth --dbpath /da1_data/play/heh/mongodb/data \
     --logpath /da1_data/play/heh/mongodb/db.log --fork --port 27020 --wiredTigerCacheSizeGB 100 \
     --bind_ip localhost,da1.eecs.utk.edu &
 ```
@@ -93,18 +93,21 @@ Make sure the MySQL server is not already running. Use the `run.sh` at `/da1_dat
 In this section, we detail on how to run this tool either locally or remotely on World of Code servers.
 
 We have two utility scripts for executing our tool: `run-local.sh` is for running locally,
- and `run-woc.sh` is for running on any of the World of Code servers. 
-However, some jobs may not work properly without access to blob database, so we strongly recommend running jobs on da4.
+ and `run-woc.sh` is for running on any of the World of Code servers. For brevity, we will only use `run-woc.sh` 
+in the script examples. For most of the jobs, if you specify the wrong parameters, usage info will be printed
+in the output.
+ 
+However, some jobs may not work properly without access to blob database, so we recommend running jobs on da4
+if you do not know whether the job uses any World of Code functionalities.
 
 ### Mining Data
 
+First, we need to initialize the databases.
+
 - CreateTableJob
 
-  创建MySQL数据表
-  
-  ```shell script
-  bash -x ./run-local.sh CreateTableJob
-  ```
+  This job is for initialize MySQL database, by creating a lot of tables. It will go wrong if the tables are 
+  already created.
   
   ```shell script
   bash -x ./run-woc.sh CreateTableJob
@@ -112,22 +115,21 @@ However, some jobs may not work properly without access to blob database, so we 
   
 - MongoDbInitializeJob
 
-  Create indexes for library data in MongoDB
+  Create indexes for library data in MongoDB. This can be run repeatedly without unsafe side effects.
   
   ```shell script
-  bash -x ./run-local.sh MongoDbInitializeJob
+  bash -x ./run-woc.sh MongoDbInitializeJob
   ```
+  
+Next, we need to import or mine data from multiple data sources.
 
 - LibrariesIoImportJob
 
-  将LibrariesIO的库数据导入数据库
-  
-  ```shell script
-  bash -x ./run-local.sh LibrariesIoImportJob
-  ```
+  Import data from the [libraries.io] dataset. It requires an additional parameter specifying which one to import.
+  Before using this, make sure the import data path in `application-xxx.yaml` is properly configured.
     
   ```shell script
-  bash -x ./run-woc.sh LibrariesIoImportJob
+  bash -x ./run-woc.sh LibrariesIoImportJob <collection-name>
   ```
 
 - LioJarParseJob
@@ -135,7 +137,7 @@ However, some jobs may not work properly without access to blob database, so we 
   从Maven下载之前导入的LibrariesIO库数据并分析，构建库与API签名映射关系
 
   ```shell script
-  bash -x ./run-local.sh LioJarParseJob 
+  bash -x ./run-woc.sh LioJarParseJob 
   ```
 
   ```shell script

--- a/src/main/java/edu/pku/migrationhelper/data/LioProject.java
+++ b/src/main/java/edu/pku/migrationhelper/data/LioProject.java
@@ -1,4 +1,4 @@
-package edu.pku.migrationhelper.data.lib;
+package edu.pku.migrationhelper.data;
 
 import org.springframework.data.annotation.Id;
 

--- a/src/main/java/edu/pku/migrationhelper/data/LioRepository.java
+++ b/src/main/java/edu/pku/migrationhelper/data/LioRepository.java
@@ -1,0 +1,257 @@
+package edu.pku.migrationhelper.data;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.util.Assert;
+
+public class LioRepository {
+
+    @Id
+    private long id;
+    private String hostType;
+    private String nameWithOwner;
+    private String description;
+    private boolean fork;
+    private String forkSourceNameWithOwner;
+    private String createdTimestamp;
+    private String updatedTimestamp;
+    private String lastPushedTimestamp;
+    private String homepageURL;
+    private String mirrorURL;
+    private long size;
+    private String language;
+    private long starsCount;
+    private long forksCount;
+    private long openIssuesCount;
+    private long watchersCount;
+    private long contributorsCount;
+    private String readmeFilename;
+    private String changeLogFilename;
+    private String contributingGuidelinesFilename;
+    private String licenseFilename;
+    private String codeOfConductFilename;
+
+    public String getName() {
+        return nameWithOwner.split("/")[1];
+    }
+
+    public String getOwner() {
+        return nameWithOwner.split("/")[0];
+    }
+
+    /**
+     * Return WoC name for GitHub repositories
+     *   Other sources are not supported but can be done later.
+     * @return WoC repository name
+     */
+    public String getWoCName() {
+        Assert.isTrue(hostType.equals("GitHub"), "Only conversion to GitHub repository is supported");
+        return nameWithOwner.replace("/", "_");
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public LioRepository setId(long id) {
+        this.id = id;
+        return this;
+    }
+
+    public String getHostType() {
+        return hostType;
+    }
+
+    public LioRepository setHostType(String hostType) {
+        this.hostType = hostType;
+        return this;
+    }
+
+    public String getNameWithOwner() {
+        return nameWithOwner;
+    }
+
+    public LioRepository setNameWithOwner(String nameWithOwner) {
+        this.nameWithOwner = nameWithOwner;
+        return this;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public LioRepository setDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public boolean isFork() {
+        return fork;
+    }
+
+    public LioRepository setFork(boolean fork) {
+        this.fork = fork;
+        return this;
+    }
+
+    public String getForkSourceNameWithOwner() {
+        return forkSourceNameWithOwner;
+    }
+
+    public LioRepository setForkSourceNameWithOwner(String forkSourceNameWithOwner) {
+        this.forkSourceNameWithOwner = forkSourceNameWithOwner;
+        return this;
+    }
+
+    public String getCreatedTimestamp() {
+        return createdTimestamp;
+    }
+
+    public LioRepository setCreatedTimestamp(String createdTimestamp) {
+        this.createdTimestamp = createdTimestamp;
+        return this;
+    }
+
+    public String getUpdatedTimestamp() {
+        return updatedTimestamp;
+    }
+
+    public LioRepository setUpdatedTimestamp(String updatedTimestamp) {
+        this.updatedTimestamp = updatedTimestamp;
+        return this;
+    }
+
+    public String getLastPushedTimestamp() {
+        return lastPushedTimestamp;
+    }
+
+    public LioRepository setLastPushedTimestamp(String lastPushedTimestamp) {
+        this.lastPushedTimestamp = lastPushedTimestamp;
+        return this;
+    }
+
+    public String getHomepageURL() {
+        return homepageURL;
+    }
+
+    public LioRepository setHomepageURL(String homepageURL) {
+        this.homepageURL = homepageURL;
+        return this;
+    }
+
+    public String getMirrorURL() {
+        return mirrorURL;
+    }
+
+    public LioRepository setMirrorURL(String mirrorURL) {
+        this.mirrorURL = mirrorURL;
+        return this;
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    public LioRepository setSize(long size) {
+        this.size = size;
+        return this;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public LioRepository setLanguage(String language) {
+        this.language = language;
+        return this;
+    }
+
+    public long getStarsCount() {
+        return starsCount;
+    }
+
+    public LioRepository setStarsCount(long starsCount) {
+        this.starsCount = starsCount;
+        return this;
+    }
+
+    public long getForksCount() {
+        return forksCount;
+    }
+
+    public LioRepository setForksCount(long forksCount) {
+        this.forksCount = forksCount;
+        return this;
+    }
+
+    public long getOpenIssuesCount() {
+        return openIssuesCount;
+    }
+
+    public LioRepository setOpenIssuesCount(long openIssuesCount) {
+        this.openIssuesCount = openIssuesCount;
+        return this;
+    }
+
+    public long getWatchersCount() {
+        return watchersCount;
+    }
+
+    public LioRepository setWatchersCount(long watchersCount) {
+        this.watchersCount = watchersCount;
+        return this;
+    }
+
+    public long getContributorsCount() {
+        return contributorsCount;
+    }
+
+    public LioRepository setContributorsCount(long contributorsCount) {
+        this.contributorsCount = contributorsCount;
+        return this;
+    }
+
+    public String getReadmeFilename() {
+        return readmeFilename;
+    }
+
+    public LioRepository setReadmeFilename(String readmeFilename) {
+        this.readmeFilename = readmeFilename;
+        return this;
+    }
+
+    public String getChangeLogFilename() {
+        return changeLogFilename;
+    }
+
+    public LioRepository setChangeLogFilename(String changeLogFilename) {
+        this.changeLogFilename = changeLogFilename;
+        return this;
+    }
+
+    public String getContributingGuidelinesFilename() {
+        return contributingGuidelinesFilename;
+    }
+
+    public LioRepository setContributingGuidelinesFilename(String contributingGuidelinesFilename) {
+        this.contributingGuidelinesFilename = contributingGuidelinesFilename;
+        return this;
+    }
+
+    public String getLicenseFilename() {
+        return licenseFilename;
+    }
+
+    public LioRepository setLicenseFilename(String licenseFilename) {
+        this.licenseFilename = licenseFilename;
+        return this;
+    }
+
+    public String getCodeOfConductFilename() {
+        return codeOfConductFilename;
+    }
+
+    public LioRepository setCodeOfConductFilename(String codeOfConductFilename) {
+        this.codeOfConductFilename = codeOfConductFilename;
+        return this;
+    }
+}

--- a/src/main/java/edu/pku/migrationhelper/job/LibrariesIoImportJob.java
+++ b/src/main/java/edu/pku/migrationhelper/job/LibrariesIoImportJob.java
@@ -1,7 +1,9 @@
 package edu.pku.migrationhelper.job;
 
-import edu.pku.migrationhelper.data.lib.LioProject;
+import edu.pku.migrationhelper.data.LioProject;
+import edu.pku.migrationhelper.data.LioRepository;
 import edu.pku.migrationhelper.repository.LioProjectRepository;
+import edu.pku.migrationhelper.repository.LioRepositoryRepository;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
@@ -16,6 +18,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.stereotype.Component;
 
 import java.io.FileReader;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,7 +26,7 @@ import java.util.List;
 @ConditionalOnProperty(name = "migration-helper.job.enabled", havingValue = "LibrariesIoImportJob")
 public class LibrariesIoImportJob implements CommandLineRunner {
 
-    Logger LOG = LoggerFactory.getLogger(getClass());
+    private final Logger LOG = LoggerFactory.getLogger(getClass());
 
     @Autowired
     private ConfigurableApplicationContext context;
@@ -31,12 +34,35 @@ public class LibrariesIoImportJob implements CommandLineRunner {
     @Value("${migration-helper.libraries-io-import.project-with-repository-path}")
     private String projectWithRepositoryPath;
 
+    @Value("${migration-helper.libraries-io-import.repository-path}")
+    private String repositoryPath;
+
     @Autowired
     private LioProjectRepository lioProjectRepository;
 
+    @Autowired
+    private LioRepositoryRepository lioRepositoryRepository;
+
     @Override
     public void run(String... args) throws Exception {
-        LOG.info("start import libraries.io project with repository");
+        if (args.length < 1) {
+            LOG.error("Usage: LibrariesIoImportJob <collectionName>");
+            System.exit(SpringApplication.exit(context, () -> -1));
+        }
+        if (args[0].equals("projectWithRepository")) {
+            importProjectWithRepository();
+        } else if (args[0].equals("repository")) {
+            importRepository();
+        } else {
+            LOG.error("Supported collection names: projectWithRepository, repository, repositoryDependency");
+            System.exit(SpringApplication.exit(context, () -> -1));
+        }
+        LOG.info("Import success");
+        System.exit(SpringApplication.exit(context, () -> 0));
+    }
+
+    private void importProjectWithRepository() throws IOException {
+        LOG.info("Start import libraries.io project with repository (i.e. Java Maven libraries)");
         FileReader fileReader = new FileReader(projectWithRepositoryPath);
         CSVParser parser = CSVFormat.DEFAULT.withFirstRecordAsHeader().parse(fileReader);
         int insertLimit = 100;
@@ -64,11 +90,56 @@ public class LibrariesIoImportJob implements CommandLineRunner {
                 results.clear();
             }
         }
-        if(results.size() > 0) {
+        if (results.size() > 0) {
             lioProjectRepository.saveAll(results);
         }
-        LOG.info("import success");
-        System.exit(SpringApplication.exit(context));
+        fileReader.close();
+    }
+
+    private void importRepository() throws IOException {
+        LOG.info("Start import libraries.io Java repository");
+        FileReader fileReader = new FileReader(repositoryPath);
+        CSVParser parser = CSVFormat.DEFAULT.withFirstRecordAsHeader().parse(fileReader);
+        int insertLimit = 10000;
+        List<LioRepository> results = new ArrayList<>(insertLimit);
+        for (CSVRecord record : parser) {
+            if (!record.get("Language").equals("Java")) {
+                continue;
+            }
+            LioRepository p = new LioRepository()
+                    .setId(getRecordLong(record, "ID"))
+                    .setHostType(record.get("Host Type"))
+                    .setNameWithOwner(record.get("Name with Owner"))
+                    .setDescription(record.get("Description"))
+                    .setFork(getRecordBoolean(record, "Fork"))
+                    .setForkSourceNameWithOwner(record.get("Fork Source Name with Owner"))
+                    .setCreatedTimestamp(record.get("Created Timestamp"))
+                    .setUpdatedTimestamp(record.get("Updated Timestamp"))
+                    .setLastPushedTimestamp(record.get("Last pushed Timestamp"))
+                    .setHomepageURL(record.get("Homepage URL"))
+                    .setMirrorURL(record.get("Mirror URL"))
+                    .setSize(getRecordLong(record, "Size"))
+                    .setLanguage(record.get("Language"))
+                    .setStarsCount(getRecordLong(record, "Stars Count"))
+                    .setForksCount(getRecordLong(record, "Forks Count"))
+                    .setOpenIssuesCount(getRecordLong(record, "Open Issues Count"))
+                    .setWatchersCount(getRecordLong(record, "Watchers Count"))
+                    .setContributorsCount(getRecordLong(record, "Contributors Count"))
+                    .setReadmeFilename(record.get("Readme filename"))
+                    .setChangeLogFilename(record.get("Changelog filename"))
+                    .setContributingGuidelinesFilename(record.get("Contributing guidelines filename"))
+                    .setLicenseFilename(record.get("License filename"))
+                    .setCodeOfConductFilename(record.get("Code of Conduct filename"));
+            results.add(p);
+            if (results.size() >= insertLimit) {
+                lioRepositoryRepository.saveAll(results);
+                results.clear();
+            }
+        }
+        if (results.size() > 0) {
+            lioRepositoryRepository.saveAll(results);
+        }
+        fileReader.close();
     }
 
     private long getRecordLong(CSVRecord record, String key) {
@@ -85,5 +156,10 @@ public class LibrariesIoImportJob implements CommandLineRunner {
         } catch (NumberFormatException e) {
             return 0;
         }
+    }
+
+    private boolean getRecordBoolean(CSVRecord record, String key) {
+        String str = record.get(key).toLowerCase();
+        return str.equals("true");
     }
 }

--- a/src/main/java/edu/pku/migrationhelper/job/LioJarParseJob.java
+++ b/src/main/java/edu/pku/migrationhelper/job/LioJarParseJob.java
@@ -2,8 +2,7 @@ package edu.pku.migrationhelper.job;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
-import edu.pku.migrationhelper.data.lib.LioProject;
-import edu.pku.migrationhelper.mapper.LioProjectWithRepositoryMapper;
+import edu.pku.migrationhelper.data.LioProject;
 import edu.pku.migrationhelper.repository.LioProjectRepository;
 import edu.pku.migrationhelper.service.EvaluationService;
 import edu.pku.migrationhelper.service.LibraryIdentityService;

--- a/src/main/java/edu/pku/migrationhelper/mapper/LioProjectWithRepositoryMapper.java
+++ b/src/main/java/edu/pku/migrationhelper/mapper/LioProjectWithRepositoryMapper.java
@@ -1,6 +1,6 @@
 package edu.pku.migrationhelper.mapper;
 
-import edu.pku.migrationhelper.data.lib.LioProject;
+import edu.pku.migrationhelper.data.LioProject;
 import org.apache.ibatis.annotations.*;
 
 import java.util.List;

--- a/src/main/java/edu/pku/migrationhelper/repository/LioProjectRepository.java
+++ b/src/main/java/edu/pku/migrationhelper/repository/LioProjectRepository.java
@@ -1,6 +1,6 @@
 package edu.pku.migrationhelper.repository;
 
-import edu.pku.migrationhelper.data.lib.LioProject;
+import edu.pku.migrationhelper.data.LioProject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;

--- a/src/main/java/edu/pku/migrationhelper/repository/LioRepositoryRepository.java
+++ b/src/main/java/edu/pku/migrationhelper/repository/LioRepositoryRepository.java
@@ -1,0 +1,10 @@
+package edu.pku.migrationhelper.repository;
+
+import edu.pku.migrationhelper.data.LioRepository;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.Optional;
+
+public interface LioRepositoryRepository extends MongoRepository<LioRepository, Long> {
+    Optional<LioRepository> findByName(String name);
+}

--- a/src/main/java/edu/pku/migrationhelper/service/EvaluationService.java
+++ b/src/main/java/edu/pku/migrationhelper/service/EvaluationService.java
@@ -1,7 +1,7 @@
 package edu.pku.migrationhelper.service;
 
 import edu.pku.migrationhelper.data.lib.LibraryGroupArtifact;
-import edu.pku.migrationhelper.data.lib.LioProject;
+import edu.pku.migrationhelper.data.LioProject;
 import edu.pku.migrationhelper.repository.LibraryGroupArtifactRepository;
 import edu.pku.migrationhelper.repository.LioProjectRepository;
 import org.apache.commons.csv.CSVFormat;

--- a/src/main/java/edu/pku/migrationhelper/service/MongoDbUtilService.java
+++ b/src/main/java/edu/pku/migrationhelper/service/MongoDbUtilService.java
@@ -1,6 +1,8 @@
 package edu.pku.migrationhelper.service;
 
 import edu.pku.migrationhelper.data.CustomSequences;
+import edu.pku.migrationhelper.data.LioProject;
+import edu.pku.migrationhelper.data.LioRepository;
 import edu.pku.migrationhelper.data.api.ClassSignature;
 import edu.pku.migrationhelper.data.lib.*;
 import org.bson.Document;
@@ -34,6 +36,10 @@ public class MongoDbUtilService {
     @Autowired
     private MongoTemplate mongoTemplate;
 
+    /**
+     * The initialization of MongoDB, which is currently responsible for creating indexes.
+     * In the future it can also be used for adding data constraints
+     */
     public void initMongoDb() {
         mongoTemplate.indexOps(ClassSignature.class).ensureIndex(new Index().on("className", Sort.Direction.ASC));
         Document compoundIndex = new Document();
@@ -64,6 +70,14 @@ public class MongoDbUtilService {
                 "dependentRepositoriesCount");
         for (String property : lioProjectProperties) {
             mongoTemplate.indexOps(LioProject.class).ensureIndex(new Index().on(property, Sort.Direction.DESC));
+        }
+
+        mongoTemplate.indexOps(LioRepository.class).ensureIndex((new Index().on("nameWithOwner", Sort.Direction.ASC)));
+        final List<String> lioRepositoryProperties = Arrays.asList(
+                "size", "starsCount", "forksCount", "openIssuesCount", "watchersCount", "contributorsCount"
+        );
+        for (String property : lioRepositoryProperties) {
+            mongoTemplate.indexOps(LioRepository.class).ensureIndex(new Index().on(property, Sort.Direction.DESC));
         }
     }
 

--- a/src/main/resources/application-woc.yaml
+++ b/src/main/resources/application-woc.yaml
@@ -46,6 +46,7 @@ migration-helper:
     repository-list-file: test_data/repositories.csv
   libraries-io-import:
     project-with-repository-path: /home/heh/libraries-1.6.0-2020-01-12/projects_with_repository_fields-1.6.0-2020-01-12.csv
+    repository-path: /home/heh/libraries-1.6.0-2020-01-12/repositories-1.6.0-2020-01-12.csv
   lio-jar-parse:
     data-source: all
     limit-count: 10000

--- a/src/test/java/repository/LibraryRelatedRepositoryTest.java
+++ b/src/test/java/repository/LibraryRelatedRepositoryTest.java
@@ -3,7 +3,7 @@ package repository;
 import edu.pku.migrationhelper.config.MongoDbConfiguration;
 import edu.pku.migrationhelper.data.lib.LibraryGroupArtifact;
 import edu.pku.migrationhelper.data.lib.LibraryVersion;
-import edu.pku.migrationhelper.data.lib.LioProject;
+import edu.pku.migrationhelper.data.LioProject;
 import edu.pku.migrationhelper.repository.LibraryGroupArtifactRepository;
 import edu.pku.migrationhelper.repository.LibraryVersionRepository;
 import edu.pku.migrationhelper.repository.LioProjectRepository;


### PR DESCRIPTION
In the original paper, it is very strange to re-use an old repo list from an ICPC-2019 paper. In the future, we choose to build dep change seq from a selected repository list based on Libraries.io (I believe it is newer and more comprehensive). This will be the first step to achieve this.

Currently the libraries.io repository database has been already constructed on World of Code MongoDB. Some manual setup will be needed for local construction, but I currently do not have any plan for that.